### PR TITLE
Separate processed paths for 2D and 3D datasets.

### DIFF
--- a/mantra/datasets.py
+++ b/mantra/datasets.py
@@ -81,7 +81,7 @@ class ManifoldTriangulations(InMemoryDataset):
         processed folder, it will skip processing. Othewise it will run the
         process function.
         """
-        return ["data.pt"]
+        return [f"data_{self.manifold}.pt"]
 
     def download(self) -> None:
         """


### PR DESCRIPTION
This pull request resolves the processed data path into two paths, one for the 3D manifolds and one for the 2D manifolds to prevent inference when loading both datasets.
Loading both datasets after one another leads to the following file tree.
```
data
└── simplicial
    ├── processed
    │   ├── data_2.pt
    │   ├── data_3.pt
    │   ├── pre_filter.pt
    │   └── pre_transform.pt
    └── raw
        ├── 2_manifolds.json
        └── 3_manifolds.json
```