### PR TITLE
Storing moment curve embedding values for all simplices

### DIFF
--- a/mantra/transforms/moment_curve_embedding.py
+++ b/mantra/transforms/moment_curve_embedding.py
@@ -92,8 +92,8 @@ def _propagate_values(X, triangulation):
         0: X,
     }
 
-    for dim in range(1, max_dim + 1):
-        simplices_ = [s for s in simplices if len(s) == dim]
+    for dim in range(1, max_dim):
+        simplices_ = [s for s in simplices if len(s) == dim + 1]
         M = []
 
         for s in simplices_:


### PR DESCRIPTION
Per the suggestion of @martin-carrasco, the moment curve embedding values are not stored in the vertices any more but also in higher-order simplices (via the barycenter). This changes the output format to a `dict`, whose keys indicate the dimensions of the simplicial complex.