### PR TITLE
Fix double tagging of Klein Bottle and #^2 RP^2

### DIFF
--- a/mantra/lex_to_json.py
+++ b/mantra/lex_to_json.py
@@ -344,8 +344,11 @@ def guess_name(triangulation):
     else:
         expected_betti_numbers = [1, g - 1, 0]
         expected_torsion_coefficients = ["", "Z_2", ""]
-
-        name = f"#^{g:d} RP^2"
+        # The Klein bottle is homeomorphic to the connected sum of two RP^2
+        if g == 2:
+            name = "Klein bottle"
+        else:
+            name = f"#^{g:d} RP^2"
 
     # We always check Betti numbers because every triangulation is
     # guaranteed to have it.


### PR DESCRIPTION
The connected sum product of two $\mathbb{RP}^2$ is *homeomorphic* to the Klein bottle, thus, they should not be disjoint classes. This fix aims to tag the instance of this connected sum as Klein bottle directly.

TODO: We should still test that the dataset does not contain any instance of ${\\#}^2 RP^2$, maybe through a test ?