### PR TITLE
Support feature propagation in the Levi graph representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ changes to this project. We adhere to [Semantic Versioning](https://semver.org/)
   transforms whose targets are fixed functions of the stored
   attributes.
 
+- `LeviGraph(feature_propagation=...)`: like `HasseDiagram` and
+  `DualGraph`, the Levi graph can now carry propagated per-rank
+  features (e.g. `x_0 ... x_d` from `PropagateConvexComb`) as node
+  features, vertices their rank-0 feature and maximal simplices the
+  feature of their own rank.
+
   `MANTRADivided` for tuning the on-the-fly balancing
   (`target_count`, `n_moves`, `use_topology_changes`, `max_vertices`,
   `verbose`).

--- a/mantra/representations/graph/levi_graph.py
+++ b/mantra/representations/graph/levi_graph.py
@@ -1,12 +1,23 @@
+from typing import Optional
+
 import networkx as nx
 from torch_geometric.data import Data
 from torch_geometric.transforms import BaseTransform
 from torch_geometric.utils import from_networkx
 
+from mantra.representations.graph.hasse_diagram import simplex_feature_index
+
 
 class LeviGraph(BaseTransform):
-    def __init__(self):
+    def __init__(self, feature_propagation: Optional[str] = None):
         super().__init__()
+        # Name of a propagated feature (e.g. `x`, as written by
+        # `PropagateConvexComb`) whose per-rank tensors `<name>_0` ...
+        # `<name>_d` supply the node features of the Levi graph:
+        # vertices carry their rank-0 feature, maximal simplices the
+        # feature of their own rank. Mirrors the interface of
+        # `HasseDiagram` / `DualGraph`.
+        self.feature_propagation = feature_propagation
 
     def forward(self, data: Data):
         """Retrieves the Levi Graph[1] of a triangulation
@@ -29,8 +40,14 @@ class LeviGraph(BaseTransform):
             `edge_index` tensor for representing the Levi graph being
             present.
         """
-        G = self._build_levi(data["triangulation"])
-        data_ = from_networkx(G)
+        G = self._build_levi(data["triangulation"], data)
+
+        if self.feature_propagation:
+            data_ = from_networkx(
+                G, group_node_attrs=[self.feature_propagation]
+            )
+        else:
+            data_ = from_networkx(G)
 
         for k, v in data_.items():
             assert k not in data
@@ -39,7 +56,7 @@ class LeviGraph(BaseTransform):
         data["n_vertices"] = G.number_of_nodes()
         return data
 
-    def _build_levi(self, top_simplices):
+    def _build_levi(self, top_simplices, data):
         """Constructs the Levi graph.
 
         The Levi graph of a triangulation $T$ of dimension $d$ is a
@@ -52,6 +69,12 @@ class LeviGraph(BaseTransform):
         top_simplices = list(set([tuple(s) for s in top_simplices]))
         top_simplices.sort()
         top_simplices.sort(key=len)
+
+        feat_index = (
+            simplex_feature_index(top_simplices)
+            if self.feature_propagation
+            else None
+        )
 
         G = nx.Graph()
 
@@ -66,11 +89,21 @@ class LeviGraph(BaseTransform):
         # integers aligned with the original (zero-indexed) vertex
         # order.
         for v in vertices:
-            G.add_node(v - 1, simplex=[v - 1])
+            attrs = {"simplex": [v - 1]}
+            if self.feature_propagation:
+                feat_tensor = getattr(data, f"{self.feature_propagation}_0")
+                attrs[self.feature_propagation] = feat_tensor[v - 1]
+            G.add_node(v - 1, **attrs)
 
         # For each maximal simplex
         for i, simp in enumerate(top_simplices):
-            G.add_node(n + i, simplex=[v - 1 for v in simp])
+            attrs = {"simplex": [v - 1 for v in simp]}
+            if self.feature_propagation:
+                feat_tensor = getattr(
+                    data, f"{self.feature_propagation}_{len(simp) - 1}"
+                )
+                attrs[self.feature_propagation] = feat_tensor[feat_index[simp]]
+            G.add_node(n + i, **attrs)
             # Connect the maximal simplex to the 0-simplices it contains
             for v in simp:
                 G.add_edge(v - 1, n + i)

--- a/mantra/representations/graph/levi_graph.py
+++ b/mantra/representations/graph/levi_graph.py
@@ -11,12 +11,6 @@ from mantra.representations.graph.hasse_diagram import simplex_feature_index
 class LeviGraph(BaseTransform):
     def __init__(self, feature_propagation: Optional[str] = None):
         super().__init__()
-        # Name of a propagated feature (e.g. `x`, as written by
-        # `PropagateConvexComb`) whose per-rank tensors `<name>_0` ...
-        # `<name>_d` supply the node features of the Levi graph:
-        # vertices carry their rank-0 feature, maximal simplices the
-        # feature of their own rank. Mirrors the interface of
-        # `HasseDiagram` / `DualGraph`.
         self.feature_propagation = feature_propagation
 
     def forward(self, data: Data):

--- a/test/test_levi_graph.py
+++ b/test/test_levi_graph.py
@@ -14,8 +14,8 @@ from mantra.representations import LeviGraph
 from mantra.transforms import PropagateConvexComb
 
 # Boundary of a tetrahedron with the top simplices deliberately given in
-# non-lexicographic order (each tuple itself internally sorted, as in
-# the CY data), pinning the index alignment of the simplex partition.
+# non-lexicographic order (each tuple itself internally sorted), pinning
+# the index alignment of the simplex partition.
 TETRAHEDRON_TRI_SCRAMBLED = [[2, 3, 4], [1, 2, 4], [1, 2, 3], [1, 3, 4]]
 # The same top simplices, 0-indexed and lexicographically sorted: the
 # order the Levi graph must use for the maximal-simplex partition.

--- a/test/test_levi_graph.py
+++ b/test/test_levi_graph.py
@@ -1,7 +1,32 @@
+"""Tests for ``mantra.representations.graph.levi_graph``.
+
+Covers the bipartite structure (0-simplices vs. maximal simplices with
+the documented 0-indexing), the ``feature_propagation=None`` default
+(parity with the pre-propagation implementation), and feature
+propagation with exact per-node values.
+"""
+
 import pytest
+import torch
 from torch_geometric.data import Data
 
 from mantra.representations import LeviGraph
+from mantra.transforms import PropagateConvexComb
+
+# Boundary of a tetrahedron with the top simplices deliberately given in
+# non-lexicographic order (each tuple itself internally sorted, as in
+# the CY data), pinning the index alignment of the simplex partition.
+TETRAHEDRON_TRI_SCRAMBLED = [[2, 3, 4], [1, 2, 4], [1, 2, 3], [1, 3, 4]]
+# The same top simplices, 0-indexed and lexicographically sorted: the
+# order the Levi graph must use for the maximal-simplex partition.
+TETRAHEDRON_TOPS_SORTED = [[0, 1, 2], [0, 1, 3], [0, 2, 3], [1, 2, 3]]
+# Two triangles sharing the edge (1, 2).
+TWO_TRIANGLES = [[1, 2, 3], [1, 2, 4]]
+
+# Vertex coordinates whose x-coordinates are powers of two: barycenters
+# of *distinct* vertex subsets are pairwise distinct, so a misindexed
+# feature lookup cannot produce the correct value by accident.
+VERTICES = torch.tensor([[1.0, 0.1], [2.0, 0.2], [4.0, 0.4], [8.0, 0.8]])
 
 
 @pytest.fixture
@@ -17,6 +42,18 @@ def single_triangle():
 @pytest.fixture
 def two_triangles():
     return [[1, 2, 3], [1, 2, 4]]
+
+
+def _edge_set(data):
+    return set(map(tuple, data.edge_index.t().tolist()))
+
+
+def _propagated_data(triangulation):
+    """Attach per-rank barycentric features `x_0`, `x_1`, `x_2`."""
+    data = Data(
+        triangulation=triangulation, dimension=2, coords=VERTICES.clone()
+    )
+    return PropagateConvexComb(source="coords")(data)
 
 
 class TestLeviGraph:
@@ -43,3 +80,105 @@ class TestLeviGraph:
         cnt_nodes = self._cnt_nodes(data)
 
         assert data.n_vertices == cnt_nodes + len(data.triangulation)
+
+
+class TestLeviGraphStructure:
+    def test_two_triangles(self):
+        out = LeviGraph()(Data(triangulation=TWO_TRIANGLES, dimension=2))
+
+        # 4 vertices + 2 top simplices.
+        assert int(out.n_vertices) == 6
+        # Vertex v becomes node v - 1; top simplex i becomes node 4 + i.
+        assert out.simplex == [[0], [1], [2], [3], [0, 1, 2], [0, 1, 3]]
+        # Exactly one (undirected) edge per vertex-in-top incidence.
+        assert _edge_set(out) == {
+            (0, 4),
+            (4, 0),
+            (1, 4),
+            (4, 1),
+            (2, 4),
+            (4, 2),
+            (0, 5),
+            (5, 0),
+            (1, 5),
+            (5, 1),
+            (3, 5),
+            (5, 3),
+        }
+
+    def test_tetrahedron_bipartite_edges(self):
+        out = LeviGraph()(
+            Data(triangulation=TETRAHEDRON_TRI_SCRAMBLED, dimension=2)
+        )
+
+        assert int(out.n_vertices) == 8
+
+        # Top-simplex nodes follow the lexicographic order of the top
+        # simplices, not the scrambled input order.
+        assert out.simplex[4:] == TETRAHEDRON_TOPS_SORTED
+
+        # Exact edge-set equality: every top simplex connects to
+        # precisely its own vertices, and no vertex-vertex or top-top
+        # edges exist (the graph is bipartite).
+        expected = set()
+        for i, top in enumerate(TETRAHEDRON_TOPS_SORTED):
+            for v in top:
+                expected.add((v, 4 + i))
+                expected.add((4 + i, v))
+        assert _edge_set(out) == expected
+
+
+class TestLeviGraphDefault:
+    def test_no_propagation_adds_no_features(self):
+        # ``feature_propagation`` defaults to ``None`` and must then
+        # reproduce the pre-propagation behavior: the bipartite graph
+        # plus the per-node ``simplex`` attribute, but no ``x``.
+        out = LeviGraph()(
+            Data(triangulation=TETRAHEDRON_TRI_SCRAMBLED, dimension=2)
+        )
+
+        assert "x" not in out
+        assert out.edge_index.shape == (2, 24)
+        assert int(out.n_vertices) == 8
+        assert out.simplex == [[0], [1], [2], [3]] + TETRAHEDRON_TOPS_SORTED
+
+    def test_no_propagation_ignores_present_features(self):
+        # Propagated features stay untouched unless asked for.
+        out = LeviGraph()(_propagated_data(TETRAHEDRON_TRI_SCRAMBLED))
+
+        assert "x" not in out
+        assert out.x_0.shape == (4, 2)
+
+
+class TestLeviGraphFeaturePropagation:
+    def _levi(self):
+        return LeviGraph(feature_propagation="x")(
+            _propagated_data(TETRAHEDRON_TRI_SCRAMBLED)
+        )
+
+    def test_vertex_nodes_carry_vertex_coordinates(self):
+        out = self._levi()
+
+        assert out.x.shape == (8, 2)
+        # Node i < 4 is vertex i + 1 and carries its raw coordinates.
+        assert torch.equal(out.x[:4], VERTICES)
+
+    def test_top_simplex_nodes_carry_their_barycenter(self):
+        out = self._levi()
+
+        assert out.simplex[4:] == TETRAHEDRON_TOPS_SORTED
+        for row, top in zip(out.x[4:], out.simplex[4:]):
+            expected = VERTICES[top].mean(dim=0)
+            assert torch.allclose(row, expected)
+
+        # All 8 features are pairwise distinct, so index misalignment
+        # between the two partitions cannot pass the checks above.
+        assert out.x.unique(dim=0).shape[0] == 8
+
+    def test_missing_rank_tensor_raises(self):
+        data = Data(
+            triangulation=TWO_TRIANGLES, dimension=2, x_0=VERTICES.clone()
+        )
+        # Rank-2 features are required for the maximal simplices.
+        with pytest.raises(AttributeError):
+            LeviGraph(feature_propagation="x")(data)

--- a/test/test_levi_graph.py
+++ b/test/test_levi_graph.py
@@ -13,19 +13,15 @@ from torch_geometric.data import Data
 from mantra.representations import LeviGraph
 from mantra.transforms import PropagateConvexComb
 
-# Boundary of a tetrahedron with the top simplices deliberately given in
-# non-lexicographic order (each tuple itself internally sorted), pinning
-# the index alignment of the simplex partition.
+# Tetrahedron boundary with the top simplices in non-lexicographic order.
 TETRAHEDRON_TRI_SCRAMBLED = [[2, 3, 4], [1, 2, 4], [1, 2, 3], [1, 3, 4]]
-# The same top simplices, 0-indexed and lexicographically sorted: the
-# order the Levi graph must use for the maximal-simplex partition.
+# The same top simplices, 0-indexed and in the order the Levi graph uses.
 TETRAHEDRON_TOPS_SORTED = [[0, 1, 2], [0, 1, 3], [0, 2, 3], [1, 2, 3]]
 # Two triangles sharing the edge (1, 2).
 TWO_TRIANGLES = [[1, 2, 3], [1, 2, 4]]
 
-# Vertex coordinates whose x-coordinates are powers of two: barycenters
-# of *distinct* vertex subsets are pairwise distinct, so a misindexed
-# feature lookup cannot produce the correct value by accident.
+# Power-of-two x-coordinates: barycenters of distinct vertex subsets are
+# pairwise distinct, so a misindexed feature lookup cannot pass by accident.
 VERTICES = torch.tensor([[1.0, 0.1], [2.0, 0.2], [4.0, 0.4], [8.0, 0.8]])
 
 
@@ -117,9 +113,7 @@ class TestLeviGraphStructure:
         # simplices, not the scrambled input order.
         assert out.simplex[4:] == TETRAHEDRON_TOPS_SORTED
 
-        # Exact edge-set equality: every top simplex connects to
-        # precisely its own vertices, and no vertex-vertex or top-top
-        # edges exist (the graph is bipartite).
+        # Bipartite: every top simplex connects to exactly its own vertices.
         expected = set()
         for i, top in enumerate(TETRAHEDRON_TOPS_SORTED):
             for v in top:
@@ -130,9 +124,7 @@ class TestLeviGraphStructure:
 
 class TestLeviGraphDefault:
     def test_no_propagation_adds_no_features(self):
-        # ``feature_propagation`` defaults to ``None`` and must then
-        # reproduce the pre-propagation behavior: the bipartite graph
-        # plus the per-node ``simplex`` attribute, but no ``x``.
+        # The default must reproduce the pre-propagation output.
         out = LeviGraph()(
             Data(triangulation=TETRAHEDRON_TRI_SCRAMBLED, dimension=2)
         )
@@ -171,8 +163,7 @@ class TestLeviGraphFeaturePropagation:
             expected = VERTICES[top].mean(dim=0)
             assert torch.allclose(row, expected)
 
-        # All 8 features are pairwise distinct, so index misalignment
-        # between the two partitions cannot pass the checks above.
+        # Pairwise distinct features make the checks above sensitive to swaps.
         assert out.x.unique(dim=0).shape[0] == 8
 
     def test_missing_rank_tensor_raises(self):


### PR DESCRIPTION
`LeviGraph(feature_propagation=None)` gains the same interface as `HasseDiagram` and `DualGraph` (#93): when a name such as `"x"` is given, the per-rank tensors `x_0 … x_d` written by `PropagateConvexComb` supply the node features of the Levi graph — vertex nodes carry their rank-0 feature, maximal-simplex nodes the feature of their own rank, looked up through `simplex_feature_index`. The default reproduces the previous behaviour exactly (no `x`, same node order and edges).

This is the Levi half of the old `calabi-yau` propagation work; the Hasse/dual half landed in #93.

**Tests:** `test/test_levi_graph.py` now pins the bipartite structure and node order on a scrambled tetrahedron, the default parity, and exact per-node feature values (vertex coordinates and barycenters chosen so that any index misalignment between the two partitions is detected). CHANGELOG updated. Full suite + black + ruff pass via the pre-commit hook.
