### PR TITLE
Keep original label in data

### DIFF
--- a/mantra/transforms/task_transforms.py
+++ b/mantra/transforms/task_transforms.py
@@ -98,6 +98,7 @@ class AttributeToClassTransform(T.BaseTransform):
 
         index = self.mapping[value]
         data.y = torch.tensor(index, dtype=torch.long)
+        data.label = value
         return data
 
 


### PR DESCRIPTION
Added a `label` attribute to the `Data` object to keep the original label for visualization / reporting purpouses