### PR TITLE
Keep the original label in the orientability task transform

### DIFF
--- a/mantra/transforms/task_transforms.py
+++ b/mantra/transforms/task_transforms.py
@@ -135,6 +135,7 @@ class OrientableToClassTransform(T.BaseTransform):
     def forward(self, data: Data):
         data.orientable = torch.tensor(data.betti_numbers)[..., -1]
         data.y = data.orientable.long()
+        data.label = bool(data.y.item())
         return data
 
 

--- a/test/test_task_transforms.py
+++ b/test/test_task_transforms.py
@@ -126,10 +126,12 @@ class TestOrientableToClassTransform:
     def test_orientable_last_betti_one(self):
         result = OrientableToClassTransform()(Data(betti_numbers=[1, 0, 1]))
         assert result.y.item() == 1
+        assert result.label is True
 
     def test_non_orientable_last_betti_zero(self):
         result = OrientableToClassTransform()(Data(betti_numbers=[1, 0, 0]))
         assert result.y.item() == 0
+        assert result.label is False
 
 
 class TestBettiToClassTransform:


### PR DESCRIPTION
Follow-up to #99: `AttributeToClassTransform` stores the raw attribute value in `data.label` next to the class index, but `OrientableToClassTransform` does not, so downstream code that reads `data.label` (e.g. test-time class naming in the benchmarks) works for one task transform and crashes for the other.

This sets `data.label` to the boolean orientability in `OrientableToClassTransform.forward` and extends its two tests with the corresponding assertions. No other behavior changes.

Tests: 34 passed in `test/test_task_transforms.py`; pre-commit (ruff, pytest) green.