### PR TITLE
CalabiYau: deterministic train/val/test splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ changes to this project. We adhere to [Semantic Versioning](https://semver.org/)
   (`target_count`, `n_moves`, `use_topology_changes`, `max_vertices`,
   `verbose`).
 
+- `CalabiYauDataset`: seeded train/val/test splits of `CalabiYau`
+  (`split_type`, `seed`, `split_proportions`, `stratified`,
+  `label_source`, `min_sample_per_class`), mirroring
+  `MantraDataset` on top of `ManifoldTriangulations`. The split
+  files encode these options, so variants coexist with the full
+  dataset.
+
 ## Removed
 
 - `CreateLabels`, which assigned class indices in encounter order and

--- a/mantra/datasets/__init__.py
+++ b/mantra/datasets/__init__.py
@@ -1,5 +1,11 @@
 from .calabi_yau import CalabiYau
+from .calabi_yau_dataset import CalabiYauDataset
 from .mantra import ManifoldTriangulations
 from .mantra_dataset import MantraDataset
 
-__all__ = ["ManifoldTriangulations", "CalabiYau", "MantraDataset"]
+__all__ = [
+    "ManifoldTriangulations",
+    "CalabiYau",
+    "CalabiYauDataset",
+    "MantraDataset",
+]

--- a/mantra/datasets/calabi_yau.py
+++ b/mantra/datasets/calabi_yau.py
@@ -24,6 +24,9 @@ class CalabiYau(InMemoryDataset):
     the simplices to 1-indexed lists and stores the *topological*
     dimension of the complex (number of vertices per top simplex minus
     one) in the `dimension` attribute.
+
+    This class serves the full dataset; train/val/test splits are
+    served by :class:`~mantra.datasets.CalabiYauDataset`.
     """
 
     def __init__(
@@ -77,6 +80,7 @@ class CalabiYau(InMemoryDataset):
             subsets are stored in their own processed directory, so
             they can coexist with the full dataset and are cheap to
             precompute, e.g. for smoke tests or timing benchmarks.
+
         batch_size : int
             Size of the batch to load from the parquet file of the
             manifold triangulations.
@@ -97,7 +101,15 @@ class CalabiYau(InMemoryDataset):
             force_reload=force_reload,
         )
 
-        self.load(self.processed_paths[0])
+        self.load(self.processed_paths[self._load_index()])
+
+    def _load_index(self):
+        """Index into ``processed_paths`` of the file to load.
+
+        Subclasses producing several processed files (e.g. one per
+        split) override this to select the right one.
+        """
+        return 0
 
     def _add_version_to_root(self):
         if self.version == "latest":
@@ -135,8 +147,8 @@ class CalabiYau(InMemoryDataset):
     def processed_file_names(self):
         """Return process file names.
 
-        Stores the processed data in a file. If this file is present in the
-        `processed` folder, processing will typically be skipped.
+        Stores the processed data in a file. If this file is present in
+        the `processed` folder, processing will typically be skipped.
         """
         return ["data.pt"]
 
@@ -213,8 +225,8 @@ class CalabiYau(InMemoryDataset):
                 return data_list
         return data_list
 
-    def process(self):
-        """Processes dataset."""
+    def _load_data_list(self) -> List[Data]:
+        """Parse the raw parquet file and apply ``pre_filter``."""
         parquet_file = pq.ParquetFile(self.raw_paths[0])
 
         data_list = self._process_parquet(parquet_file)
@@ -225,6 +237,12 @@ class CalabiYau(InMemoryDataset):
                 for data in tqdm(data_list, desc="Filtering")
                 if self.pre_filter(data)
             ]
+
+        return data_list
+
+    def process(self):
+        """Processes dataset."""
+        data_list = self._load_data_list()
 
         if self.pre_transform is not None:
             data_list = [

--- a/mantra/datasets/calabi_yau.py
+++ b/mantra/datasets/calabi_yau.py
@@ -175,7 +175,9 @@ class CalabiYau(InMemoryDataset):
         """
         data_list = []
 
-        for pq_batch in parquet_file.iter_batches(batch_size=self.parquet_batch_size):
+        for pq_batch in parquet_file.iter_batches(
+            batch_size=self.parquet_batch_size
+        ):
             parquet_df = pq_batch.to_pandas()
             for _, row in parquet_df.iterrows():
                 row_dict = row.to_dict()

--- a/mantra/datasets/calabi_yau.py
+++ b/mantra/datasets/calabi_yau.py
@@ -40,7 +40,7 @@ class CalabiYau(InMemoryDataset):
         pre_transform=None,
         pre_filter=None,
         force_reload=False,
-        batch_size: int = 1000,
+        parquet_batch_size: int = 1000,
     ):
         """
         Create a new CY-Manifolds dataset.
@@ -81,7 +81,7 @@ class CalabiYau(InMemoryDataset):
             they can coexist with the full dataset and are cheap to
             precompute, e.g. for smoke tests or timing benchmarks.
 
-        batch_size : int
+        parquet_batch_size : int
             Size of the batch to load from the parquet file of the
             manifold triangulations.
         """
@@ -89,7 +89,7 @@ class CalabiYau(InMemoryDataset):
         self.name = name
         self.local_path = os.path.abspath(local_path) if local_path else None
         self.limit = limit
-        self.batch_size = batch_size
+        self.parquet_batch_size = parquet_batch_size
 
         root += self._add_version_to_root()
 
@@ -109,7 +109,7 @@ class CalabiYau(InMemoryDataset):
         Subclasses producing several processed files (e.g. one per
         split) override this to select the right one.
         """
-        return 0
+        return int(0)
 
     def _add_version_to_root(self):
         if self.version == "latest":
@@ -175,7 +175,7 @@ class CalabiYau(InMemoryDataset):
         """
         data_list = []
 
-        for pq_batch in parquet_file.iter_batches(batch_size=self.batch_size):
+        for pq_batch in parquet_file.iter_batches(batch_size=self.parquet_batch_size):
             parquet_df = pq_batch.to_pandas()
             for _, row in parquet_df.iterrows():
                 row_dict = row.to_dict()
@@ -231,18 +231,18 @@ class CalabiYau(InMemoryDataset):
 
         data_list = self._process_parquet(parquet_file)
 
+        return data_list
+
+    def process(self):
+        """Processes dataset."""
+        data_list = self._load_data_list()
+
         if self.pre_filter is not None:
             data_list = [
                 data
                 for data in tqdm(data_list, desc="Filtering")
                 if self.pre_filter(data)
             ]
-
-        return data_list
-
-    def process(self):
-        """Processes dataset."""
-        data_list = self._load_data_list()
 
         if self.pre_transform is not None:
             data_list = [

--- a/mantra/datasets/calabi_yau_dataset.py
+++ b/mantra/datasets/calabi_yau_dataset.py
@@ -1,9 +1,9 @@
 import math
 from typing import List
 
+import torch
 from tqdm import tqdm
 
-import torch
 from mantra.datasets.calabi_yau import CalabiYau
 from mantra.datasets.utils import make_split_index
 
@@ -134,7 +134,6 @@ class CalabiYauDataset(CalabiYau):
         """Split the parsed data and save one file per split."""
         data_list = self._load_data_list()
 
-
         if self.pre_filter is not None:
             data_list = [
                 data
@@ -162,7 +161,6 @@ class CalabiYauDataset(CalabiYau):
             test_size=self.split_proportions[2],
             labels=labels,
         )
-
 
         # WARN: This is order specific (must match SPLIT_TYPES).
         for path, index in zip(

--- a/mantra/datasets/calabi_yau_dataset.py
+++ b/mantra/datasets/calabi_yau_dataset.py
@@ -1,0 +1,171 @@
+import math
+from typing import List
+
+import numpy as np
+from tqdm import tqdm
+
+from mantra.datasets.calabi_yau import CalabiYau
+from mantra.datasets.utils import filter_by_class_count, make_split_index
+
+SPLIT_TYPES = ["train", "val", "test"]
+DEFAULT_SPLIT_PROPORTIONS = [0.6, 0.2, 0.2]
+
+
+class CalabiYauDataset(CalabiYau):
+    """Train/val/test split of the :class:`CalabiYau` dataset.
+
+    Mirrors :class:`~mantra.datasets.MantraDataset`: the full data is
+    split once into seeded, deterministic train/val/test parts and each
+    instance serves the part selected by ``split_type``. The split
+    files live next to the full ``data.pt`` of the base class and their
+    names encode every option that changes the splits, so differently
+    seeded, proportioned, filtered or stratified variants coexist.
+    """
+
+    def __init__(
+        self,
+        root,
+        split_type: str,
+        version="latest",
+        name=None,
+        local_path=None,
+        limit=None,
+        transform=None,
+        pre_transform=None,
+        pre_filter=None,
+        force_reload=False,
+        seed: int = 42,
+        split_proportions: List[float] = DEFAULT_SPLIT_PROPORTIONS,
+        stratified: bool = False,
+        label_source: str = "h11",
+        min_sample_per_class: int | None = None,
+        batch_size: int = 1000,
+    ):
+        """
+        Create a split of the CY-Manifolds dataset.
+
+        Parameters
+        ----------
+        split_type : str
+            One of ``train``, ``val`` or ``test``.
+
+        seed : int
+            Seed of the split assignment.
+
+        split_proportions : List[float]
+            Proportional split in terms of [train, val, test]. Must sum
+            to 1.
+
+        stratified : bool
+            If to use stratified splitting by the values of
+            ``label_source``. Every value then needs enough samples to
+            appear in each split, so combine it with
+            ``min_sample_per_class``.
+
+        label_source : str
+            Attribute whose values define the classes used by
+            ``stratified`` and ``min_sample_per_class``, e.g. ``h11``.
+
+        min_sample_per_class : int or None
+            Drop the samples whose ``label_source`` value occurs at most
+            this many times before splitting. ``None`` keeps every
+            sample.
+
+        The remaining parameters are those of :class:`CalabiYau`.
+        """
+        if split_type not in SPLIT_TYPES:
+            raise ValueError(
+                f"split_type must be one of {SPLIT_TYPES}, got '{split_type}'"
+            )
+        if len(split_proportions) != 3 or not math.isclose(
+            sum(split_proportions), 1.0
+        ):
+            raise ValueError(
+                "split_proportions must be [train, val, test] summing to 1, "
+                f"got {split_proportions}"
+            )
+
+        self.split_type = split_type
+        self.seed = seed
+        self.split_proportions = split_proportions
+        self.stratified = stratified
+        self.label_source = label_source
+        self.min_sample_per_class = min_sample_per_class
+
+        super().__init__(
+            root,
+            version=version,
+            name=name,
+            local_path=local_path,
+            limit=limit,
+            transform=transform,
+            pre_transform=pre_transform,
+            pre_filter=pre_filter,
+            force_reload=force_reload,
+            batch_size=batch_size,
+        )
+
+    def _load_index(self):
+        """Load the processed file matching ``split_type``."""
+        return SPLIT_TYPES.index(self.split_type)
+
+    def _split_file_suffix(self):
+        """Suffix encoding the options that change the splits.
+
+        The processed directory of :class:`CalabiYau` carries no seed
+        (unlike :class:`ManifoldTriangulations`), so the seed is part
+        of the file names.
+        """
+        parts = [f"seed{self.seed}"]
+        if self.split_proportions != DEFAULT_SPLIT_PROPORTIONS:
+            parts.append(
+                "sp" + "-".join(str(p) for p in self.split_proportions)
+            )
+        if self.min_sample_per_class:
+            parts.append(f"ccf{self.min_sample_per_class}")
+        if self.stratified:
+            parts.append("strat")
+        if self.min_sample_per_class or self.stratified:
+            parts.append(self.label_source)
+        return "_" + "_".join(parts)
+
+    @property
+    def processed_file_names(self):
+        """Return process file names, one per split."""
+        suffix = self._split_file_suffix()
+        return [f"{split_type}{suffix}.pt" for split_type in SPLIT_TYPES]
+
+    def process(self):
+        """Split the parsed data and save one file per split."""
+        data_list = self._load_data_list()
+
+        data_list, _ = filter_by_class_count(
+            data_list, self.label_source, self.min_sample_per_class
+        )
+
+        labels = (
+            np.array([data[self.label_source] for data in data_list])
+            if self.stratified
+            else None
+        )
+
+        train_index, val_index, test_index = make_split_index(
+            data_list_size=len(data_list),
+            seed=self.seed,
+            train_size=self.split_proportions[0],
+            val_size=self.split_proportions[1],
+            test_size=self.split_proportions[2],
+            labels=labels,
+        )
+
+        if self.pre_transform is not None:
+            data_list = [
+                self.pre_transform(data)
+                for data in tqdm(data_list, desc="Pre-transforming")
+            ]
+
+        # WARN: This is order specific (must match SPLIT_TYPES).
+        for path, index in zip(
+            self.processed_paths, (train_index, val_index, test_index)
+        ):
+            self.save([data_list[idx] for idx in index], path)

--- a/mantra/datasets/calabi_yau_dataset.py
+++ b/mantra/datasets/calabi_yau_dataset.py
@@ -1,11 +1,11 @@
 import math
 from typing import List
 
-import numpy as np
 from tqdm import tqdm
 
+import torch
 from mantra.datasets.calabi_yau import CalabiYau
-from mantra.datasets.utils import filter_by_class_count, make_split_index
+from mantra.datasets.utils import make_split_index
 
 SPLIT_TYPES = ["train", "val", "test"]
 DEFAULT_SPLIT_PROPORTIONS = [0.6, 0.2, 0.2]
@@ -38,8 +38,7 @@ class CalabiYauDataset(CalabiYau):
         split_proportions: List[float] = DEFAULT_SPLIT_PROPORTIONS,
         stratified: bool = False,
         label_source: str = "h11",
-        min_sample_per_class: int | None = None,
-        batch_size: int = 1000,
+        parquet_batch_size: int = 1000,
     ):
         """
         Create a split of the CY-Manifolds dataset.
@@ -90,7 +89,6 @@ class CalabiYauDataset(CalabiYau):
         self.split_proportions = split_proportions
         self.stratified = stratified
         self.label_source = label_source
-        self.min_sample_per_class = min_sample_per_class
 
         super().__init__(
             root,
@@ -102,7 +100,7 @@ class CalabiYauDataset(CalabiYau):
             pre_transform=pre_transform,
             pre_filter=pre_filter,
             force_reload=force_reload,
-            batch_size=batch_size,
+            parquet_batch_size=parquet_batch_size,
         )
 
     def _load_index(self):
@@ -121,11 +119,8 @@ class CalabiYauDataset(CalabiYau):
             parts.append(
                 "sp" + "-".join(str(p) for p in self.split_proportions)
             )
-        if self.min_sample_per_class:
-            parts.append(f"ccf{self.min_sample_per_class}")
         if self.stratified:
             parts.append("strat")
-        if self.min_sample_per_class or self.stratified:
             parts.append(self.label_source)
         return "_" + "_".join(parts)
 
@@ -139,15 +134,25 @@ class CalabiYauDataset(CalabiYau):
         """Split the parsed data and save one file per split."""
         data_list = self._load_data_list()
 
-        data_list, _ = filter_by_class_count(
-            data_list, self.label_source, self.min_sample_per_class
-        )
+
+        if self.pre_filter is not None:
+            data_list = [
+                data
+                for data in tqdm(data_list, desc="Filtering")
+                if self.pre_filter(data)
+            ]
 
         labels = (
-            np.array([data[self.label_source] for data in data_list])
+            torch.tensor([data[self.label_source] for data in data_list])
             if self.stratified
             else None
         )
+
+        if self.pre_transform is not None:
+            data_list = [
+                self.pre_transform(data)
+                for data in tqdm(data_list, desc="Pre-transforming")
+            ]
 
         train_index, val_index, test_index = make_split_index(
             data_list_size=len(data_list),
@@ -158,11 +163,6 @@ class CalabiYauDataset(CalabiYau):
             labels=labels,
         )
 
-        if self.pre_transform is not None:
-            data_list = [
-                self.pre_transform(data)
-                for data in tqdm(data_list, desc="Pre-transforming")
-            ]
 
         # WARN: This is order specific (must match SPLIT_TYPES).
         for path, index in zip(

--- a/mantra/datasets/calabi_yau_dataset.py
+++ b/mantra/datasets/calabi_yau_dataset.py
@@ -1,7 +1,7 @@
 import math
 from typing import List
 
-import torch
+import numpy as np
 from tqdm import tqdm
 
 from mantra.datasets.calabi_yau import CalabiYau
@@ -142,7 +142,7 @@ class CalabiYauDataset(CalabiYau):
             ]
 
         labels = (
-            torch.tensor([data[self.label_source] for data in data_list])
+            np.array([data[self.label_source] for data in data_list])
             if self.stratified
             else None
         )

--- a/mantra/datasets/mantra_dataset.py
+++ b/mantra/datasets/mantra_dataset.py
@@ -5,8 +5,8 @@ from collections import defaultdict
 from enum import Enum
 from typing import List
 
-import torch
 import numpy as np
+import torch
 from torch_geometric.data import (
     Data,
 )

--- a/mantra/datasets/mantra_dataset.py
+++ b/mantra/datasets/mantra_dataset.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from enum import Enum
 from typing import List
 
-import numpy as np
+import torch
 from torch_geometric.data import (
     Data,
 )
@@ -344,7 +344,7 @@ class MantraDataset(ManifoldTriangulations):
 
         # Get the class labels
         labels = (
-            np.array([data.name for data in data_list])
+            torch.tensor([data.name for data in data_list])
             if self.stratified
             else None
         )

--- a/mantra/datasets/mantra_dataset.py
+++ b/mantra/datasets/mantra_dataset.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import List
 
 import torch
+import numpy as np
 from torch_geometric.data import (
     Data,
 )

--- a/mantra/datasets/mantra_dataset.py
+++ b/mantra/datasets/mantra_dataset.py
@@ -6,7 +6,6 @@ from enum import Enum
 from typing import List
 
 import numpy as np
-import torch
 from torch_geometric.data import (
     Data,
 )
@@ -345,7 +344,7 @@ class MantraDataset(ManifoldTriangulations):
 
         # Get the class labels
         labels = (
-            torch.tensor([data.name for data in data_list])
+            np.array([data.name for data in data_list])
             if self.stratified
             else None
         )

--- a/test/test_datasets_cy.py
+++ b/test/test_datasets_cy.py
@@ -195,24 +195,6 @@ class TestCYStratified:
         assert counts["val"] == {0: 2, 1: 2, 2: 2}
         assert counts["test"] == {0: 2, 1: 2, 2: 2}
 
-    def test_min_sample_per_class_drops_rare_values(
-        self, tmp_path, make_cy_parquet
-    ):
-        rows = _numbered_rows(20)
-        rows[-1]["h12"] = 99
-        splits = [
-            _load_split(
-                tmp_path,
-                make_cy_parquet,
-                rows,
-                split_type,
-                min_sample_per_class=1,
-                label_source="h12",
-            )
-            for split_type in ("train", "val", "test")
-        ]
-        seen = sorted(int(data.h11) for ds in splits for data in ds)
-        assert seen == list(range(19))
 
     def test_stratified_needs_populated_classes(
         self, tmp_path, make_cy_parquet
@@ -236,7 +218,6 @@ class TestCYStratified:
         )
         obj.stratified = kwargs.pop("stratified", False)
         obj.label_source = kwargs.pop("label_source", "h11")
-        obj.min_sample_per_class = kwargs.pop("min_sample_per_class", None)
         return obj.processed_file_names
 
     def test_file_names_encode_split_options(self):
@@ -246,11 +227,11 @@ class TestCYStratified:
             "test_seed42.pt",
         ]
         assert self._names(
-            stratified=True, min_sample_per_class=2, label_source="h11"
+            stratified=True,  label_source="h11"
         ) == [
-            "train_seed42_ccf2_strat_h11.pt",
-            "val_seed42_ccf2_strat_h11.pt",
-            "test_seed42_ccf2_strat_h11.pt",
+            "train_seed42_strat_h11.pt",
+            "val_seed42_strat_h11.pt",
+            "test_seed42_strat_h11.pt",
         ]
         assert self._names(seed=7, split_proportions=[0.5, 0.1, 0.4]) == [
             "train_seed7_sp0.5-0.1-0.4.pt",

--- a/test/test_datasets_cy.py
+++ b/test/test_datasets_cy.py
@@ -195,7 +195,6 @@ class TestCYStratified:
         assert counts["val"] == {0: 2, 1: 2, 2: 2}
         assert counts["test"] == {0: 2, 1: 2, 2: 2}
 
-
     def test_stratified_needs_populated_classes(
         self, tmp_path, make_cy_parquet
     ):
@@ -226,9 +225,7 @@ class TestCYStratified:
             "val_seed42.pt",
             "test_seed42.pt",
         ]
-        assert self._names(
-            stratified=True,  label_source="h11"
-        ) == [
+        assert self._names(stratified=True, label_source="h11") == [
             "train_seed42_strat_h11.pt",
             "val_seed42_strat_h11.pt",
             "test_seed42_strat_h11.pt",

--- a/test/test_datasets_cy.py
+++ b/test/test_datasets_cy.py
@@ -1,14 +1,26 @@
-"""Tests for the parquet-based CY dataset."""
+"""Tests for the parquet-based CY dataset and its splits."""
 
+from collections import Counter
+
+import pytest
 import torch
 
-from mantra.datasets import CalabiYau
+from mantra.datasets import CalabiYau, CalabiYauDataset
 
 
 def _load(tmp_path, make_cy_parquet, cy_rows, **kwargs):
     return CalabiYau(
         root=str(tmp_path / "data"),
         local_path=make_cy_parquet(cy_rows),
+        **kwargs,
+    )
+
+
+def _load_split(tmp_path, make_cy_parquet, rows, split_type, **kwargs):
+    return CalabiYauDataset(
+        root=str(tmp_path / "data"),
+        split_type=split_type,
+        local_path=make_cy_parquet(rows),
         **kwargs,
     )
 
@@ -61,3 +73,187 @@ class TestCY:
         full = _load(tmp_path, make_cy_parquet, cy_rows)
         assert "variant_a" not in full.processed_dir
         assert len(full) == len(cy_rows)
+
+
+def _numbered_rows(n):
+    """CY-style rows whose ``h11`` enumerates the samples and whose
+    ``h12`` cycles through three values."""
+    simplices = [[0, 1, 2], [0, 2, 3], [0, 3, 4], [0, 4, 1]]
+    vertices = [
+        [0, 0],
+        [1, 0],
+        [0, 1],
+        [-1, 0],
+        [0, -1],
+    ]
+    return [
+        {
+            "simplices": simplices,
+            "vertices": vertices,
+            "h11": i,
+            "h12": i % 3,
+        }
+        for i in range(n)
+    ]
+
+
+def _ids(dataset):
+    return sorted(int(data.h11) for data in dataset)
+
+
+class TestCYSplits:
+    def test_splits_partition_the_dataset(self, tmp_path, make_cy_parquet):
+        rows = _numbered_rows(20)
+        splits = {
+            split_type: _load_split(
+                tmp_path, make_cy_parquet, rows, split_type
+            )
+            for split_type in ("train", "val", "test")
+        }
+
+        # Default proportions [0.6, 0.2, 0.2] of 20 samples.
+        assert len(splits["train"]) == 12
+        assert len(splits["val"]) == 4
+        assert len(splits["test"]) == 4
+
+        seen = [int(data.h11) for ds in splits.values() for data in ds]
+        assert sorted(seen) == list(range(20))
+
+    def test_splits_are_deterministic(self, tmp_path, make_cy_parquet):
+        rows = _numbered_rows(20)
+        first = _load_split(tmp_path, make_cy_parquet, rows, "val", seed=7)
+        again = _load_split(
+            tmp_path / "other_root", make_cy_parquet, rows, "val", seed=7
+        )
+        assert _ids(first) == _ids(again)
+
+    def test_seed_changes_the_assignment(self, tmp_path, make_cy_parquet):
+        rows = _numbered_rows(40)
+        default = _load_split(tmp_path, make_cy_parquet, rows, "test", seed=42)
+        reseeded = _load_split(
+            tmp_path, make_cy_parquet, rows, "test", seed=43
+        )
+        # Differently seeded splits live in differently named files.
+        assert default.processed_paths != reseeded.processed_paths
+        assert _ids(default) != _ids(reseeded)
+
+    def test_split_proportions_change_sizes(self, tmp_path, make_cy_parquet):
+        rows = _numbered_rows(20)
+        test = _load_split(
+            tmp_path,
+            make_cy_parquet,
+            rows,
+            "test",
+            split_proportions=[0.5, 0.1, 0.4],
+        )
+        assert len(test) == 8
+
+    def test_full_dataset_coexists_with_splits(
+        self, tmp_path, make_cy_parquet
+    ):
+        rows = _numbered_rows(20)
+        train = _load_split(tmp_path, make_cy_parquet, rows, "train")
+        full = _load(tmp_path, make_cy_parquet, rows)
+        assert len(train) == 12
+        assert len(full) == 20
+
+    def test_invalid_split_type_rejected(self, tmp_path, make_cy_parquet):
+        with pytest.raises(ValueError, match="split_type"):
+            _load_split(tmp_path, make_cy_parquet, _numbered_rows(5), "ood")
+
+    def test_invalid_proportions_rejected(self, tmp_path, make_cy_parquet):
+        with pytest.raises(ValueError, match="split_proportions"):
+            _load_split(
+                tmp_path,
+                make_cy_parquet,
+                _numbered_rows(5),
+                "train",
+                split_proportions=[0.8, 0.1, 0.2],
+            )
+
+
+class TestCYStratified:
+    def test_stratified_split_balances_label_source(
+        self, tmp_path, make_cy_parquet
+    ):
+        rows = _numbered_rows(30)
+        counts = {
+            split_type: Counter(
+                int(data.h12)
+                for data in _load_split(
+                    tmp_path,
+                    make_cy_parquet,
+                    rows,
+                    split_type,
+                    stratified=True,
+                    label_source="h12",
+                )
+            )
+            for split_type in ("train", "val", "test")
+        }
+        assert counts["train"] == {0: 6, 1: 6, 2: 6}
+        assert counts["val"] == {0: 2, 1: 2, 2: 2}
+        assert counts["test"] == {0: 2, 1: 2, 2: 2}
+
+    def test_min_sample_per_class_drops_rare_values(
+        self, tmp_path, make_cy_parquet
+    ):
+        rows = _numbered_rows(20)
+        rows[-1]["h12"] = 99
+        splits = [
+            _load_split(
+                tmp_path,
+                make_cy_parquet,
+                rows,
+                split_type,
+                min_sample_per_class=1,
+                label_source="h12",
+            )
+            for split_type in ("train", "val", "test")
+        ]
+        seen = sorted(int(data.h11) for ds in splits for data in ds)
+        assert seen == list(range(19))
+
+    def test_stratified_needs_populated_classes(
+        self, tmp_path, make_cy_parquet
+    ):
+        # Every `h11` value occurs once, which sklearn cannot stratify.
+        with pytest.raises(ValueError, match="least populated"):
+            _load_split(
+                tmp_path,
+                make_cy_parquet,
+                _numbered_rows(20),
+                "train",
+                stratified=True,
+                label_source="h11",
+            )
+
+    def _names(self, **kwargs):
+        obj = CalabiYauDataset.__new__(CalabiYauDataset)
+        obj.seed = kwargs.pop("seed", 42)
+        obj.split_proportions = kwargs.pop(
+            "split_proportions", [0.6, 0.2, 0.2]
+        )
+        obj.stratified = kwargs.pop("stratified", False)
+        obj.label_source = kwargs.pop("label_source", "h11")
+        obj.min_sample_per_class = kwargs.pop("min_sample_per_class", None)
+        return obj.processed_file_names
+
+    def test_file_names_encode_split_options(self):
+        assert self._names() == [
+            "train_seed42.pt",
+            "val_seed42.pt",
+            "test_seed42.pt",
+        ]
+        assert self._names(
+            stratified=True, min_sample_per_class=2, label_source="h11"
+        ) == [
+            "train_seed42_ccf2_strat_h11.pt",
+            "val_seed42_ccf2_strat_h11.pt",
+            "test_seed42_ccf2_strat_h11.pt",
+        ]
+        assert self._names(seed=7, split_proportions=[0.5, 0.1, 0.4]) == [
+            "train_seed7_sp0.5-0.1-0.4.pt",
+            "val_seed7_sp0.5-0.1-0.4.pt",
+            "test_seed7_sp0.5-0.1-0.4.pt",
+        ]


### PR DESCRIPTION
Adds seeded train/val/test splits for the Calabi-Yau data, structured like the MANTRA datasets: `CalabiYau` stays the full dataset and a new `CalabiYauDataset` subclass serves one split, the way `MantraDataset` sits on `ManifoldTriangulations`.

- `CalabiYau` only gains the `_load_index()` hook of `ManifoldTriangulations` and a `_load_data_list()` helper (parquet parsing + `pre_filter`) that the subclass reuses.
- `CalabiYauDataset(root, split_type, ..., seed=42, split_proportions=[0.6, 0.2, 0.2], stratified=False, label_source="h11", min_sample_per_class=None)`: `split_type` is one of train/val/test; `stratified` stratifies on the values of `label_source` and `min_sample_per_class` drops the values with at most that many samples first, both through the helpers `MantraDataset` uses (`make_split_index`, `filter_by_class_count`). CY samples have no `name`, hence the explicit `label_source`.
- The split files encode the options (`train_seed42.pt`, `train_seed42_ccf2_strat_h11.pt`, `train_seed7_sp0.5-0.1-0.4.pt`, ...) and live next to the full `data.pt`, so variants coexist. Unlike `ManifoldTriangulations`, the `CalabiYau` processed directory carries no seed, which is why the seed is in the file name.
- Tests in `test/test_datasets_cy.py` cover partition, determinism, seeds, proportions, coexistence with the full dataset, stratified balance, the class filter, the sklearn error for unpopulated classes, and the file names. CHANGELOG entry added.

Consumer: aidos-lab/mantra-pp-benchmarks#15 (`dataset=cy`).
