### PR TITLE
Curate .gitignore, fix docs rendering and stale examples, backfill changelog

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -1,18 +1,18 @@
 name: Create new dataset release for Zenodo and Github.
 
-on: 
+on:
   workflow_dispatch:
-  push: 
+  push:
     tags:
       - "v*.*.*"
 
-jobs: 
-  run-python: 
+jobs:
+  run-python:
     runs-on: ubuntu-latest
-    steps: 
+    steps:
       - name: Checkout code
-        uses: actions/checkout@v3
-  
+        uses: actions/checkout@v6
+
       - name: Install Python and dependencies
         uses: actions/setup-python@v5
         with:
@@ -24,25 +24,29 @@ jobs:
           pip install requests
 
       - name: Run data conversion script
-        run: | 
+        run: |
           sh scripts/convert_manifolds.sh
-      
+
+      # The top `# vX.Y.Z` section of CHANGELOG.md is the version being released.
+      - name: Extract release notes for this version
+        run: awk '/^# v[0-9]/{n++} n==1' CHANGELOG.md > release_notes.md
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
           draft: false
-          body_path: CHANGELOG.md
-          generate_release_notes: false  # Just use `CHANGELOG.md`
+          body_path: release_notes.md
+          generate_release_notes: false
           make_latest: true
           files: |
             2_manifolds.json.gz
             3_manifolds.json.gz
-      
+
       - name: Get latest tag
         id: get_tag
         run: |
           echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      
+
       - name: Create new Zenodo release
         env:
           TOKEN: ${{ secrets.ZENODO_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,43 @@
-uv.lock
-**/raw
-data/
-bu/
-*.json
-
-test_*
-!test/test_*.py
+# Python
 **/__pycache__
+*.py[cod]
+*.so
 **/*.egg-info
-
-processed/**
-scratch_**
-
 /build
-/visualization 
-/tables
+/dist
 
-docs/build
+# Environments
+.venv/
+.venv-*/
+venv/
 
-site/
-
-# Coverage data
+# Tooling caches
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
 .coverage
+.coverage.*
+htmlcov/
+
+# IDE / OS (.idea/ is ignored user-wide in ~/.config/git/ignore)
+.DS_Store
+
+# Claude Code: local agent state. A shared .claude/settings.json may be committed.
+.claude/*
+!.claude/settings.json
+/CLAUDE.md
+
+# Notebooks
+.ipynb_checkpoints/
+
+# Data and artefacts. Root-anchored *.json keeps the manifold downloads out
+# while leaving .claude/settings.json and future config JSON committable.
+/*.json
+data/
+**/raw/
+processed/**
+
+# Library: uv.lock stays untracked, CI resolves fresh via `uv sync`.
+uv.lock
+docs/build/
+site/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ changes to this project. We adhere to [Semantic Versioning](https://semver.org/)
   therefore depended on dataset traversal; use
   `AttributeToClassTransform` or a name transform instead.
 
+- `scripts/generate_balanced.py` (superseded by on-the-fly balancing)
+  and the `balanced` parameter of the internal dataset URL helper.
+
 ## Changed
 
 - `balanced=True` now computes the balanced dataset during `process()`
@@ -43,10 +46,42 @@ changes to this project. We adhere to [Semantic Versioning](https://semver.org/)
   covers stellar subdivision with `fraction=1.0`, which is just as
   deterministic as barycentric subdivision.
 
-## Removed
+# v0.0.19
 
-- `scripts/generate_balanced.py` (superseded by on-the-fly balancing)
-  and the `balanced` parameter of the internal dataset URL helper.
+Release fixes only (version resolution in `mantra/__init__.py` and the
+PyPI release script). No functional changes since v0.0.17.
+
+# v0.0.18
+
+Release fixes only. No functional changes since v0.0.17.
+
+# v0.0.17
+
+## Added
+
+- `mantra.representations`: `OneSkeleton`, `DualGraph`, `HasseDiagram`,
+  and the simplicial-complex connectivity representations
+  `IncidenceSimplicialComplex`, `AdjacencySimplicialComplex`, and
+  `CoadjacencySimplicialComplex`, backed by an internal simplex trie.
+- `mantra.transforms` as a package: `MomentCurveEmbedding` (with
+  optional propagation to higher-order simplices), `NodeRandomTransform`,
+  `NodeDegreeTransform`, `SelectFeatures`, `SelectAttributes`, and
+  `CreateLabels`.
+- `PairwiseSimplicialDS`, a dataset of triangulation pairs.
+- `name` parameter of `ManifoldTriangulations` so that several processed
+  variants can coexist under one root.
+
+## Changed
+
+- `ManifoldTriangulations(manifold=...)` is now `dimension=...`.
+- The package is built with `uv` and hatchling with a dynamically
+  derived version, and is formatted with black and checked with ruff in
+  CI.
+
+## Fixed
+
+- Indexing in the dual-graph construction and off-by-one errors in the
+  moment-curve embedding.
 
 # v0.0.16
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ A: Topology forms a fundamental theoretical foundation for natural sciences like
 
 
 #### Q: Which are the main functions and classes implemented in this dataset?
-A: The core class of the MANTRA package is `ManifoldTriangulations`. `ManifoldTriangulations` allows the user to load the MANTRA dataset using a `InMemoryDataset` format from [`torch_geometric`](https://pytorch-geometric.readthedocs.io/en/latest/). The transforms `NodeIndex`, `RandomNodeFeatures`, `DegreeTransform`, and `DegreeTransformOneHot`are also provided in this package. Concretely, `NodeIndex` transforms the original triangulation format in a torch-like tensor, and `RandomNodeFeatures`, `DegreeTransform`, and `DegreeTransformOneHot` assign input feature vectors to vertices in a the `x` attribute of the input `Data` representing a triangulation based either on random features or on the degree of each vertex, respectively.
+A: The core class of the MANTRA package is `ManifoldTriangulations`. `ManifoldTriangulations` allows the user to load the MANTRA dataset using a `InMemoryDataset` format from [`torch_geometric`]([`torch_geometric`](https://pytorch-geometric.readthedocs.io/en/latest/)). Additionally, the `MantraDataset` class allows loading a dataset split.
 
 *Have a question that's not answered here? Please open an issue on our GitHub repository.*
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,24 +27,21 @@ for using graph neural networks:
 
 ```python
 from torch_geometric.transforms import Compose
-from torch_geometric.transforms import FaceToEdge
 
 from mantra.datasets import ManifoldTriangulations
-from mantra.transforms import NodeIndex
-from mantra.transforms import RandomNodeFeatures
+from mantra.transforms import NodeRandomTransform, SelectFeatures
+from mantra.representations import OneSkeleton
 
 
 dataset = ManifoldTriangulations(
-    root="./data",
-    dimension=2,
-    version="latest",
-    transform=Compose(
+    root="./data", # Root of the dataset
+    dimension=2, # Dimension of the manifolds in question
+    version="latest", # Which version of the dataset to load
+    pre_transform=Compose( # Set of transforms to be applied during preprocessing
         [
-            NodeIndex(),
-            RandomNodeFeatures(),
-            # Converts face indices to edge indices, thus essentially
-            # making the 1-skeleton available to a model.
-            FaceToEdge(remove_faces=False),
+            OneSkeleton(),
+            NodeRandomTransform(), # Assigns random features (default dim=8) on the attribute `random_features`
+            SelectFeatures(src="random_features", dst=None, representation="graph"), # Assing `x = random_features`
         ]
     ),
     force_reload=True,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,7 @@ plugins:
         python:
           paths: [mantra,.]
           options:
-            docstring_style: google
+            docstring_style: numpy
             docstring_section_style: list
   - mkdocs-autoapi:
       autoapi_dir: mantra


### PR DESCRIPTION
- `mkdocs.yml`: `docstring_style: numpy`. The code base uses NumPy docstrings throughout (87 `Parameters` sections, zero Google `Args:`), so with `google` the generated API pages rendered section headers as literal text.
- `docs/installation.md`: the example imported `NodeIndex` and `RandomNodeFeatures`, which no longer exist; it now mirrors the README example (`OneSkeleton`, `NodeRandomTransform`, `SelectFeatures`). `docs/index.md`: FAQ answer synced with the README.
- `CHANGELOG.md`: merge the duplicated `## Removed` under `Unreleased`; add entries for v0.0.17 (the representations/transforms restructuring, `dimension` rename, uv build) and v0.0.18/v0.0.19 (release fixes only), which were tagged without entries.
- `create_release.yaml`: the release body is now only the top `# vX.Y.Z` section instead of the whole changelog.
- `.gitignore`: curated. `*.json` is root-anchored so the manifold downloads stay ignored while `.claude/settings.json` and future config JSON are committable; the `test_*` rule (which hid nothing but would swallow any `mantra/test_*.py` module) is dropped; venvs, IDE and Claude Code state, `.DS_Store` added. `git ls-files -ci` under the new rules lists only `data/.gitkeep`, as before.