### PR TITLE
Use the balanced entries in MantraDataset.process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ changes to this project. We adhere to [Semantic Versioning](https://semver.org/)
   therefore depended on dataset traversal; use
   `AttributeToClassTransform` or a name transform instead.
 
+## Fixed
+
+- `MantraDataset(balanced=True)` balanced nothing since the split
+  refactor; the augmented and deduplicated entries are now used.
+
 ## Changed
 
 - `balanced=True` now computes the balanced dataset during `process()`

--- a/mantra/datasets/mantra_dataset.py
+++ b/mantra/datasets/mantra_dataset.py
@@ -321,7 +321,7 @@ class MantraDataset(ManifoldTriangulations):
         if self.balanced:
             # balance_dataset enforces the vertex cap itself, both as a
             # prefilter and during augmentation.
-            inputs = balance_dataset(
+            data_list = balance_dataset(
                 data_list,
                 seed=self.seed,
                 max_vertices=self.max_vertices,

--- a/test/test_mantra_divided.py
+++ b/test/test_mantra_divided.py
@@ -385,6 +385,28 @@ class TestBalancedDivided:
         assert sizes["train"] + sizes["val"] + sizes["test"] == 8
         assert sizes["ood"] == sizes["test"]
 
+    def test_every_class_is_balanced_to_target_count(
+        self, make_manifolds_json, tmp_path, no_dedup
+    ):
+        entries = [manifold_entry(f"s{i}", name="S^2") for i in range(7)] + [
+            manifold_entry(f"r{i}", name="RP^2", orientable=False)
+            for i in range(2)
+        ]
+        counts = Counter()
+        for split in ["train", "val", "test"]:
+            ds = make_divided(
+                make_manifolds_json,
+                entries,
+                tmp_path,
+                split_type=split,
+                balanced=True,
+                target_count=5,
+                n_moves=1,
+                use_surgery=False,
+            )
+            counts.update(d.name for d in ds)
+        assert counts == {"S^2": 5, "RP^2": 5}
+
     def test_processed_dir_separates_balanced(
         self, make_manifolds_json, balanced_entries, tmp_path, no_dedup
     ):


### PR DESCRIPTION
The result of balance_dataset was assigned to an unused local (`inputs`) since the split refactor in #86, so MantraDataset(balanced=True) silently returned the unbalanced splits. Passing a pre-balanced JSON via local_path was unaffected, which is why it went unnoticed.

Adds a regression test that a balanced dataset has exactly target_count entries per class across train+val+test, and a CHANGELOG entry. Caches under processed/balanced_<seed>_* were produced by the no-op path and need force_reload=True.